### PR TITLE
Update themes.css

### DIFF
--- a/src/renderer/themes.css
+++ b/src/renderer/themes.css
@@ -290,7 +290,7 @@ it can be safely elided. This looks quite pleasant on this theme. */
   --bg-color: #1e1e2e;
   --favorite-icon-color: #0f0;
   --card-bg-color: #181825;
-  --secondary-card-bg-color: #1e1e2e;
+  --secondary-card-bg-color: #640473;
   --scrollbar-color: #313244;
   --scrollbar-color-hover: #3d4051;
   --side-nav-color: #181825;


### PR DESCRIPTION
Pull Request Type
 Bugfix
 Feature Implementation
 Documentation
 Other
Related issue
closes https://github.com/FreeTubeApp/FreeTube/issues/6597

Description
This pull request improves the color contrast of the uploader's username in the Catppuccin Mocha theme to meet accessibility standards. The contrast for the username's highlight around comments from the uploader was previously too low. Now, it adheres to a higher contrast ratio, ensuring better readability and accessibility for users.

The fix modifies the CSS for the Catppuccin Mocha theme to make the uploader's comment more distinguishable, by adjusting the relevant colors used in the theme.

Screenshots


Before: (Screenshot showing the low contrast issue):
![Screenshot 2025-03-19 215720](https://github.com/user-attachments/assets/030698e2-04a9-430e-84c1-e2de02d8afc9)
after:
![Screenshot 2025-03-19 215558](https://github.com/user-attachments/assets/4ce1c01d-f428-4928-8281-cd391dca550a)
Testing
The changes were tested locally by running the FreeTube application and setting the theme to Catppuccin Mocha.
I verified that the color contrast of the uploader's name was improved across different environments.
There are no remaining ramifications or errors related to this fix.
Desktop
OS: windows 11 pro
OS Version: 10.0.26100 
FreeTube version: 0.23.2